### PR TITLE
fix: gif파일은 원본 이미지를 불러오는 것으로 수정

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,6 +60,8 @@ export const getRevisedImageUrl = ({
   format?: "webp" | "jpg" | "auto";
 }) => {
   if (src.includes("s3.us-west-2.amazonaws")) return src;
+  if (src.includes("gif")) return src;
+
   const prefixIndex = src.lastIndexOf("upload");
   const prefix = src.slice(0, prefixIndex);
   const restUrl = src.replace(prefix, "").replace("upload/", "");


### PR DESCRIPTION
# des
`next/Image` 적용 안하는 부분때문에, 이미지가 너무 느려지는 것 같아서
`gif` 파일만 원본을 불러오는 걸로 수정